### PR TITLE
Update to work with sanic 21.6.2

### DIFF
--- a/examples/user_simple_storage/extentions/exceptions.py
+++ b/examples/user_simple_storage/extentions/exceptions.py
@@ -24,4 +24,4 @@ def handle_404(request, exception):
 @blueprint.exception(HandleValidationError)
 def handle_422(request, exception):
     error = {"messages": exception.exc.messages}
-    return json(error, status=HTTPStatus.UNPROCESSABLE_ENTITY)
+    return json(error, status=exception.status_code)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ sanic
 # Testing
 pytest
 pytest-cov
+webtest-sanic>=0.3.0
 mock
 pytest-aiohttp
 webtest

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,10 @@ sanic
 # Testing
 pytest
 pytest-cov
-webtest-sanic>=0.3.0
 mock
 pytest-aiohttp
 webtest
+sanic_testing
 
 #Coverage
 codecov>=2.0.15

--- a/tests/apps/sanic_app.py
+++ b/tests/apps/sanic_app.py
@@ -79,13 +79,19 @@ async def echo_use_args(request, args):
     return J(args)
 
 
-@app.route("/echo_use_args_validated", methods=["GET", "POST"])
+@app.route("/echo_use_args_validated", methods=["POST"])
 @use_args(
-    {"value": fields.Int(required=True)}, location="query" ,validate=lambda args: args["value"] > 42
+    {"value": fields.Int()}, validate=lambda args: args["value"] > 42, location="form"
 )
 async def echo_use_args_validated(request, args):
     return J(args)
 
+@app.route("/echo_use_args_validated", methods=["GET"])
+@use_args(
+    {"value": fields.Int()}, validate=lambda args: args["value"] > 42, location="query"
+)
+async def echo_use_args_validated(request, args):
+    return J(args)
 
 @app.route("/echo_ignoring_extra_data", methods=["POST"])
 async def echo_json_ignore_extra_data(request):

--- a/tests/apps/sanic_app.py
+++ b/tests/apps/sanic_app.py
@@ -27,7 +27,7 @@ class HelloSchema(ma.Schema):
 strict_kwargs = {} #{"strict": True} if MARSHMALLOW_VERSION_INFO[0] < 3 else {}
 hello_many_schema = HelloSchema(many=True, **strict_kwargs)
 
-app = Sanic(__name__)
+app = Sanic(__name__.replace('.', '_'))
 if (version.parse(sanic_version) < version.parse("20.0.0")):
     app.config.from_object(TestAppConfig)
 else:
@@ -244,6 +244,6 @@ async def echo_use_kwargs_missing(request, username, **kwargs):
 # Return validation errors as JSON
 @app.exception(HandleValidationError)
 async def handle_validation_error(request, err):
-    if err.data["status_code"] == 422:
+    if err.status_code == 422:
         assert isinstance(err.data["schema"], ma.Schema)
-    return J(err.exc.messages, status=err.data["status_code"])
+    return J(err.exc.messages, status=err.status_code)

--- a/tests/test_sanicparser.py
+++ b/tests/test_sanicparser.py
@@ -7,19 +7,19 @@ from sanic.exceptions import SanicException
 from sanic import __version__ as sanic_version
 from packaging import version
 
-from webargs import fields, ValidationError, missing
-from webargs_sanic.sanicparser import parser, abort
-#from webargs.core import MARSHMALLOW_VERSION_INFO
+from webargs import ValidationError
+from webargs_sanic.sanicparser import abort
 
 from .apps.sanic_app import app
-from webargs.testing import CommonTestCase
-from webtest_sanic import TestApp
-import asyncio
 import pytest
 import io
 
 
-class TestSanicParser(CommonTestCase):
+@pytest.fixture
+def testapp():
+    return app.test_client
+
+class TestSanicParser:
     def create_app(self):
         return app
 
@@ -29,68 +29,57 @@ class TestSanicParser(CommonTestCase):
     def test_parse_files(self, testapp):
         pass
 
-
-    def create_testapp(self, app):
-        loop = asyncio.get_event_loop()
-        self.loop = loop
-        return TestApp(app, loop=self.loop)
-
     def after_create_app(self):
         self.loop.close()
 
     def test_parsing_view_args(self, testapp):
-        res = testapp.get("/echo_view_arg/42")
+        _, res = testapp.get("/echo_view_arg/42")
         assert res.json == {"view_arg": 42}
 
     def test_parsing_invalid_view_arg(self, testapp):
-        res = testapp.get("/echo_view_arg/foo", expect_errors=True)
+        _, res = testapp.get("/echo_view_arg/foo")
         assert res.status_code == 422
         assert res.content_type == "application/json"
         assert res.json == {'view_args': {'view_arg': ['Not a valid integer.']}}
 
     def test_use_args_with_view_args_parsing(self, testapp):
-        res = testapp.get("/echo_view_arg_use_args/42")
+        _, res = testapp.get("/echo_view_arg_use_args/42")
         assert res.json == {"view_arg": 42}
 
     def test_use_args_on_a_method_view(self, testapp):
-        res = testapp.post("/echo_method_view_use_args", {"val": 42})
+        _, res = testapp.post("/echo_method_view_use_args", params={"val": 42})
         assert res.json == {"val": 42}
 
     def test_use_args_on_a_LOLgather_view(self, testapp):
-        res = testapp.post("/echo_lol")
+        _, res = testapp.post("/echo_lol")
         assert res.json == {'name': 'World'}
 
     def test_use_kwargs_on_a_method_view(self, testapp):
-        res = testapp.post("/echo_method_view_use_kwargs", {"val": 42})
+        _, res = testapp.post("/echo_method_view_use_kwargs", params={"val": 42})
         assert res.json == {"val": 42}
 
     def test_use_kwargs_with_missing_data(self, testapp):
-        res = testapp.post("/echo_use_kwargs_missing", {"username": "foo"}, expect_errors=True)
+        _, res = testapp.post("/echo_use_kwargs_missing", data={"username": "foo"})
         assert res.json == {"username": "foo"}
 
     def test_invalid_json(self, testapp):
-        res = testapp.post(
+        _, res = testapp.post(
             "/echo_json",
-            '{"foo": "bar", jdhfjdhjsd}',
+            content='{"foo": "bar", jdhfjdhjsd}',
             headers={"Accept": "application/json", "Content-Type": "application/json"},
-            expect_errors=True,
         )
         assert res.status_code == 400
         assert res.json == {'json': ['Invalid JSON body.']}
 
     # regression test for https://github.com/sloria/webargs/issues/145
     def test_nested_many_with_data_key(self, testapp):
-        post_with_raw_fieldname_args = (
-            "/echo_nested_many_data_key",
-            {"x_field": [{"id": 42}]},
-        )
-        res = testapp.post_json(*post_with_raw_fieldname_args, expect_errors=True)
+        _, res = testapp.post("/echo_nested_many_data_key", json={"x_field": [{"id": 42}]})
         assert res.status_code == 422
 
-        res = testapp.post_json("/echo_nested_many_data_key", {"X-Field": [{"id": 24}]})
+        _, res = testapp.post("/echo_nested_many_data_key", json={"X-Field": [{"id": 24}]})
         assert res.json == {"x_field": [{"id": 24}]}
 
-        res = testapp.post_json("/echo_nested_many_data_key", {})
+        _, res = testapp.post("/echo_nested_many_data_key", json={})
         assert res.json == {}
 
 
@@ -115,11 +104,11 @@ def test_abort_called_on_validation_error(mock_abort, loop):
 def test_parse_files(loop):
     print(version.parse(sanic_version))
     if (version.parse(sanic_version) < version.parse("19.0.0")):
-        res = app.test_client.post(
+        _, res = app.test_client.post(
             "/echo_file", data={"myfile": io.BytesIO(b"data")}, gather_request=False
         )
     else:
-        res = app.test_client.post(
+        _, res = app.test_client.post(
         "/echo_file", files=[("myfile", io.BytesIO(b"data"))], gather_request=False
     )
 

--- a/tests/test_sanicparser.py
+++ b/tests/test_sanicparser.py
@@ -31,8 +31,12 @@ class TestSanicParser(CommonTestCase):
             return TestApp(app, loop=self.loop)
         else:
             from .utils import SanicTestingTestApp
-
+            self.loop = None
             return SanicTestingTestApp(app)
+
+    def after_create_app(self):
+        if self.loop:
+            self.loop.close()
 
     # testing of file uploads is made through sanic.test_client
     # please check test_parse_files function below

--- a/tests/test_sanicparser.py
+++ b/tests/test_sanicparser.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 import json
 import mock
+import asyncio
 
 from sanic.exceptions import SanicException
 from sanic import __version__ as sanic_version
@@ -9,19 +10,29 @@ from packaging import version
 
 from webargs import ValidationError
 from webargs_sanic.sanicparser import abort
+from webargs.testing import CommonTestCase
+from sanic.server import serve, HttpProtocol
 
 from .apps.sanic_app import app
 import pytest
 import io
 
 
-@pytest.fixture
-def testapp():
-    return app.test_client
-
-class TestSanicParser:
+class TestSanicParser(CommonTestCase):
     def create_app(self):
         return app
+
+    def create_testapp(self, app):
+        if (version.parse(sanic_version) < version.parse("21.0.0")):
+            from webtest_sanic import TestApp
+
+            loop = asyncio.get_event_loop()
+            self.loop = loop
+            return TestApp(app, loop=self.loop)
+        else:
+            from .utils import SanicTestingTestApp
+
+            return SanicTestingTestApp(app)
 
     # testing of file uploads is made through sanic.test_client
     # please check test_parse_files function below
@@ -29,57 +40,59 @@ class TestSanicParser:
     def test_parse_files(self, testapp):
         pass
 
-    def after_create_app(self):
-        self.loop.close()
-
     def test_parsing_view_args(self, testapp):
-        _, res = testapp.get("/echo_view_arg/42")
+        res = testapp.get("/echo_view_arg/42")
         assert res.json == {"view_arg": 42}
 
     def test_parsing_invalid_view_arg(self, testapp):
-        _, res = testapp.get("/echo_view_arg/foo")
+        res = testapp.get("/echo_view_arg/foo", expect_errors=True)
         assert res.status_code == 422
         assert res.content_type == "application/json"
         assert res.json == {'view_args': {'view_arg': ['Not a valid integer.']}}
 
     def test_use_args_with_view_args_parsing(self, testapp):
-        _, res = testapp.get("/echo_view_arg_use_args/42")
+        res = testapp.get("/echo_view_arg_use_args/42")
         assert res.json == {"view_arg": 42}
 
     def test_use_args_on_a_method_view(self, testapp):
-        _, res = testapp.post("/echo_method_view_use_args", params={"val": 42})
+        res = testapp.post("/echo_method_view_use_args", params={"val": 42})
         assert res.json == {"val": 42}
 
     def test_use_args_on_a_LOLgather_view(self, testapp):
-        _, res = testapp.post("/echo_lol")
+        res = testapp.post("/echo_lol")
         assert res.json == {'name': 'World'}
 
     def test_use_kwargs_on_a_method_view(self, testapp):
-        _, res = testapp.post("/echo_method_view_use_kwargs", params={"val": 42})
+        res = testapp.post("/echo_method_view_use_kwargs", params={"val": 42})
         assert res.json == {"val": 42}
 
     def test_use_kwargs_with_missing_data(self, testapp):
-        _, res = testapp.post("/echo_use_kwargs_missing", data={"username": "foo"})
+        res = testapp.post("/echo_use_kwargs_missing", {"username": "foo"})
         assert res.json == {"username": "foo"}
 
     def test_invalid_json(self, testapp):
-        _, res = testapp.post(
+        res = testapp.post(
             "/echo_json",
-            content='{"foo": "bar", jdhfjdhjsd}',
+            '{"foo": "bar", jdhfjdhjsd}',
             headers={"Accept": "application/json", "Content-Type": "application/json"},
+            expect_errors=True
         )
         assert res.status_code == 400
         assert res.json == {'json': ['Invalid JSON body.']}
 
     # regression test for https://github.com/sloria/webargs/issues/145
     def test_nested_many_with_data_key(self, testapp):
-        _, res = testapp.post("/echo_nested_many_data_key", json={"x_field": [{"id": 42}]})
+        post_with_raw_fieldname_args = (
+            "/echo_nested_many_data_key",
+            {"x_field": [{"id": 42}]},
+        )
+        res = testapp.post_json(*post_with_raw_fieldname_args, expect_errors=True)
         assert res.status_code == 422
 
-        _, res = testapp.post("/echo_nested_many_data_key", json={"X-Field": [{"id": 24}]})
+        res = testapp.post_json("/echo_nested_many_data_key", {"X-Field": [{"id": 24}]})
         assert res.json == {"x_field": [{"id": 24}]}
 
-        _, res = testapp.post("/echo_nested_many_data_key", json={})
+        res = testapp.post_json("/echo_nested_many_data_key", {})
         assert res.json == {}
 
 
@@ -105,11 +118,11 @@ def test_parse_files(loop):
     print(version.parse(sanic_version))
     if (version.parse(sanic_version) < version.parse("19.0.0")):
         _, res = app.test_client.post(
-            "/echo_file", data={"myfile": io.BytesIO(b"data")}, gather_request=False
+            "/echo_file", data={"myfile": io.BytesIO(b"data")}
         )
     else:
         _, res = app.test_client.post(
-        "/echo_file", files=[("myfile", io.BytesIO(b"data"))], gather_request=False
+        "/echo_file", files=[("myfile", io.BytesIO(b"data"))]
     )
 
     assert res.json == {"myfile": "data"}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,39 @@
+
+class TestClient:
+    def __init__(self, client):
+        self._client = client
+
+    def request(self, method, uri, *args, **kwargs):
+        _, response = self._client.request(
+            uri, http_method=method, *args, **kwargs
+        )
+        return response
+
+
+class SanicTestingTestApp:
+    def __init__(self, app):
+        self._app = app
+        self._client = TestClient(app.test_client)
+        self._cookies = {}
+
+    def set_cookie(self, key, value):
+        self._cookies[key] = value
+
+    def request(self, method, uri, *args, **kwargs):
+        kwargs.pop("expect_errors", None)
+        response = self._client.request(
+            method, uri, cookies=self._cookies, *args, **kwargs
+        )
+        return response
+
+    def get(self, uri, *args, **kwargs):
+        return self.request("GET", uri, *args, **kwargs)
+
+    def post(self, uri, data=None, content_type=None, *args, **kwargs):
+        headers = kwargs.pop('headers', {})
+        if content_type:
+            headers["content-type"] = content_type
+        return self.request("POST", uri, headers=headers, data=data, *args, **kwargs)
+
+    def post_json(self, uri, data=None, *args, **kwargs):
+        return self.request("POST", uri, json=data, *args, **kwargs)

--- a/webargs_sanic/sanicparser.py
+++ b/webargs_sanic/sanicparser.py
@@ -41,7 +41,8 @@ def abort(http_status_code, exc=None, **kwargs):
 
     From Flask-Restful. See NOTICE file for license information.
     """
-    err = HandleValidationError(status_code=http_status_code)
+    message = kwargs.get("message")
+    err = HandleValidationError(status_code=http_status_code, message=message)
     err.data = kwargs
 
     if exc and not hasattr(exc, 'messages'):


### PR DESCRIPTION
Updating it to work with 21.6.2.

Had to replace `webtest-sanic` with the official `sanic_testing` since the former didn't work with recent versions of sanic.

This fixes:
- DeprecationWarning: Sanic instance named 'tests.apps.sanic_app' uses a format that is deprecated.
- Deprecation of sanic.exceptions.abort https://github.com/sanic-org/sanic/pull/2077
- Removal of sanic.exceptions.add_status_code https://github.com/sanic-org/sanic/pull/2077