### PR TITLE
Removing unused version imports.

### DIFF
--- a/webargs_sanic/sanicparser.py
+++ b/webargs_sanic/sanicparser.py
@@ -31,8 +31,7 @@ from webargs.asyncparser import AsyncParser
 from webargs.core import json as wa_json
 from webargs.multidictproxy import MultiDictProxy
 from marshmallow import Schema, ValidationError, RAISE
-from packaging import version
-from sanic import __version__ as sanic_version
+
 
 class HandleValidationError(sanic.exceptions.SanicException):
     status_code = 422


### PR DESCRIPTION
Fixes an issue with the package not working if `packaging` is not installed. It's not currently installed since it's not on the setup.py.

I've decided to remove it since it's not being used instead of adding it to setup.py.
Also, removed `from sanic import __version__ as sanic_version` just for clean up since it's not used.